### PR TITLE
Support CLI mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,5 +104,8 @@ Name                    commandLine             Env                     Descript
 address                 --address               NUTS_ADDRESS            address and port server will be listening at.
 configfile              --configfile            NUTS_CONFIGFILE         points to the location of the config file to be used.
 verbosity               --verbosity             NUTS_VERBOSITY          Log level ("trace", "debug", "info", "warn", "error")
+mode                    --mode                  NUTS_MODE               Mode the application will run in. When 'cli' it can be used to
+                                                                        administer a remote Nuts node. When 'server' it will start a Nuts node.
+                                                                        Defaults to 'server'.
 =====================   ====================    =====================   ================================================================
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,7 +39,12 @@ var rootCmd = &cobra.Command{
 	Use:   "nuts",
 	Short: "The Nuts service executable",
 	Run: func(cmd *cobra.Command, args []string) {
-
+		cfg := core.NutsConfig()
+		if cfg.Mode() != core.GlobalServerMode {
+			logrus.Error("Please specify a sub command when running in CLI mode")
+			_ = cmd.Help()
+			return
+		}
 		// start interfaces
 		echo := echo.New()
 		echo.HideBanner = true
@@ -53,9 +58,6 @@ var rootCmd = &cobra.Command{
 		}
 
 		defer shutdownEngines()
-
-		cfg := core.NutsConfig()
-
 		logrus.Fatal(echo.Start(cfg.ServerAddress()))
 	},
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/deepmap/oapi-codegen/pkg/runtime"
+	core "github.com/nuts-foundation/nuts-go-core"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func Test_rootCmd(t *testing.T) {
+	t.Run("start in CLI mode", func(t *testing.T) {
+		var routesCalled = false
+		core.RegisterEngine(&core.Engine{
+			Routes: func(router runtime.EchoRouter) {
+				routesCalled = true
+			},
+		})
+		os.Setenv("NUTS_MODE", core.GlobalCLIMode)
+		defer os.Unsetenv("NUTS_MODE")
+		assert.NoError(t, rootCmd.Execute())
+		assert.False(t, routesCalled, "engine.Routes was called")
+	})
+}

--- a/docs/pages/configuration/nuts-go.rst
+++ b/docs/pages/configuration/nuts-go.rst
@@ -43,4 +43,7 @@ Name                    commandLine             Env                     Descript
 address                 --address               NUTS_ADDRESS            address and port server will be listening at.
 configfile              --configfile            NUTS_CONFIGFILE         points to the location of the config file to be used.
 verbosity               --verbosity             NUTS_VERBOSITY          Log level ("trace", "debug", "info", "warn", "error")
+mode                    --mode                  NUTS_MODE               Mode the application will run in. When 'cli' it can be used to
+                                                                        administer a remote Nuts node. When 'server' it will start a Nuts node.
+                                                                        Defaults to 'server'.
 =====================   ====================    =====================   ================================================================

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/nuts-foundation/nuts-crypto v0.0.0-20200212103614-2acc644ddfed
 	github.com/nuts-foundation/nuts-event-octopus v0.0.0-20200221101525-20c912b75512
 	github.com/nuts-foundation/nuts-fhir-validation v0.0.0-20200212102712-c0c46c3062c4
-	github.com/nuts-foundation/nuts-go-core v0.0.0-20200221103113-05e1c6b6c5fc
+	github.com/nuts-foundation/nuts-go-core v0.0.0-20200224092142-03e29f635429
 	github.com/nuts-foundation/nuts-registry v0.0.0-20200221092912-d62eff310549
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/sirupsen/logrus v1.4.2

--- a/go.mod
+++ b/go.mod
@@ -4,24 +4,25 @@ go 1.13
 
 require (
 	github.com/bwesterb/go-xmssmt v1.0.4 // indirect
-	github.com/deepmap/oapi-codegen v1.3.4 // indirect
+	github.com/deepmap/oapi-codegen v1.3.4
 	github.com/labstack/echo v3.3.10+incompatible // indirect
 	github.com/labstack/echo/v4 v4.1.14
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/nuts-foundation/consent-bridge-go-client v0.0.0-20200121093403-d1ec6e23ab2d
-	github.com/nuts-foundation/nuts-auth v0.0.2-0.20200212101636-7478ba87e314
-	github.com/nuts-foundation/nuts-consent-logic v0.0.0-20200130105206-3855170c055f
-	github.com/nuts-foundation/nuts-consent-store v0.0.0-20200206083919-07f174baa8e2
-	github.com/nuts-foundation/nuts-crypto v0.0.0-20200127075335-afcefe897a71
-	github.com/nuts-foundation/nuts-event-octopus v0.0.0-20200206083853-1b0a343c1495
+	github.com/nuts-foundation/nuts-auth v0.0.2-0.20200221092805-456744aae40d
+	github.com/nuts-foundation/nuts-consent-logic v0.0.0-20200221113059-d08a785780ec
+	github.com/nuts-foundation/nuts-consent-store v0.0.0-20200221113149-c393282605f5
+	github.com/nuts-foundation/nuts-crypto v0.0.0-20200212103614-2acc644ddfed
+	github.com/nuts-foundation/nuts-event-octopus v0.0.0-20200221101525-20c912b75512
 	github.com/nuts-foundation/nuts-fhir-validation v0.0.0-20200212102712-c0c46c3062c4
-	github.com/nuts-foundation/nuts-go-core v0.0.0-20200130105519-4620adf455e9
-	github.com/nuts-foundation/nuts-registry v0.0.0-20200211142433-9d1d2985be8e
+	github.com/nuts-foundation/nuts-go-core v0.0.0-20200221103113-05e1c6b6c5fc
+	github.com/nuts-foundation/nuts-registry v0.0.0-20200221092912-d62eff310549
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.6.2 // indirect
+	github.com/stretchr/testify v1.4.0
 	github.com/timshannon/bolthold v0.0.0-20191009161117-ccb01ed9dec4 // indirect
 	golang.org/x/crypto v0.0.0-20200117160349-530e935923ad // indirect
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa // indirect

--- a/go.sum
+++ b/go.sum
@@ -379,6 +379,8 @@ github.com/nuts-foundation/nuts-go-core v0.0.0-20200220093939-3a4292f30472 h1:Vx
 github.com/nuts-foundation/nuts-go-core v0.0.0-20200220093939-3a4292f30472/go.mod h1:xltL3S+vqhSMYkTRIWyaVgtDk7y8KIENZmTbVIPIMcw=
 github.com/nuts-foundation/nuts-go-core v0.0.0-20200221103113-05e1c6b6c5fc h1:3ze3s0e0ZC38Q+TUVZ0BAV8m4wz+AN06HW3WKIYa+Ig=
 github.com/nuts-foundation/nuts-go-core v0.0.0-20200221103113-05e1c6b6c5fc/go.mod h1:xltL3S+vqhSMYkTRIWyaVgtDk7y8KIENZmTbVIPIMcw=
+github.com/nuts-foundation/nuts-go-core v0.0.0-20200224092142-03e29f635429 h1:3C7Qf07phJj8CP1IgO+qoBLXe42TvNcGFx7+ToK/pzY=
+github.com/nuts-foundation/nuts-go-core v0.0.0-20200224092142-03e29f635429/go.mod h1:xltL3S+vqhSMYkTRIWyaVgtDk7y8KIENZmTbVIPIMcw=
 github.com/nuts-foundation/nuts-registry v0.0.0-20191209153959-67dd0910b057 h1:kn5VkvVJWdf0suyC2AO6QlGEK+0V62Vv6B54mINecmo=
 github.com/nuts-foundation/nuts-registry v0.0.0-20191209153959-67dd0910b057/go.mod h1:zj8lpRLEYlJkC7fo+c8NO7pjkSXR3DvvpyyJ2YSiBKU=
 github.com/nuts-foundation/nuts-registry v0.0.0-20200108100157-f61ac82980f3 h1:voUFUGUDXBEYX8wJKzHRAYcOH/rc5VIaRPWwg3wmP90=

--- a/go.sum
+++ b/go.sum
@@ -313,12 +313,16 @@ github.com/nuts-foundation/nuts-auth v0.0.2-0.20200206083733-f3b8b887b466 h1:VqD
 github.com/nuts-foundation/nuts-auth v0.0.2-0.20200206083733-f3b8b887b466/go.mod h1:vTcw5FkBXNnq+358CTp5P5SE7DGKfJGldNEuEy1bySo=
 github.com/nuts-foundation/nuts-auth v0.0.2-0.20200212101636-7478ba87e314 h1:pTNLz0VW1ews1oPwJTfGpwsww6YsWjYCfhaEh4sXYfY=
 github.com/nuts-foundation/nuts-auth v0.0.2-0.20200212101636-7478ba87e314/go.mod h1:vTcw5FkBXNnq+358CTp5P5SE7DGKfJGldNEuEy1bySo=
+github.com/nuts-foundation/nuts-auth v0.0.2-0.20200221092805-456744aae40d h1:8RpmHlrk7hbF5euifVbpphllqGRiLqCUuTwsIV88dMw=
+github.com/nuts-foundation/nuts-auth v0.0.2-0.20200221092805-456744aae40d/go.mod h1:kyQZj2WgMkjorHqoCsIBbykjv85Xs0/YTWgu3KnTVaM=
 github.com/nuts-foundation/nuts-consent-logic v0.0.0-20200108104842-7dead69f7e77 h1:i/D9/Trpc4kR/S181L+p+gMMLk93Vn641/Ai/pHx0JY=
 github.com/nuts-foundation/nuts-consent-logic v0.0.0-20200108104842-7dead69f7e77/go.mod h1:M4VLBZdWhSAPh4CuXM2n1NLpMg1rBiC9f7sCYQM/HNM=
 github.com/nuts-foundation/nuts-consent-logic v0.0.0-20200124143712-6764185c064c h1:EvRhYjJdO2pacZHa6wy1N85rZifkO7pV0GBI1h9odtg=
 github.com/nuts-foundation/nuts-consent-logic v0.0.0-20200124143712-6764185c064c/go.mod h1:8PD9YBb3oZb5tW9gkxpuJ7GUhX98JnJUcxP5aK6gsj4=
 github.com/nuts-foundation/nuts-consent-logic v0.0.0-20200130105206-3855170c055f h1:0VbD5fS0GLsEHtqPMAS9fODyNS2YKb5yJZk2AvK8S5E=
 github.com/nuts-foundation/nuts-consent-logic v0.0.0-20200130105206-3855170c055f/go.mod h1:8PD9YBb3oZb5tW9gkxpuJ7GUhX98JnJUcxP5aK6gsj4=
+github.com/nuts-foundation/nuts-consent-logic v0.0.0-20200221113059-d08a785780ec h1:UdzDQ65WxXuiFeaCepD6aVHvpG1iyC51emLNyNa6k58=
+github.com/nuts-foundation/nuts-consent-logic v0.0.0-20200221113059-d08a785780ec/go.mod h1:gZeAoaQz0zLqbzetE2ZFpW4AbSfoLI5so/hsXkyR8pQ=
 github.com/nuts-foundation/nuts-consent-store v0.0.0-20191220084624-9ef684a1b27e h1:BhUndFmGeYcHfSmCe8NzpzvPNOMSrhNRZD6umkrbSDo=
 github.com/nuts-foundation/nuts-consent-store v0.0.0-20191220084624-9ef684a1b27e/go.mod h1:Q1WEjEHULIDmaP+JiX9Iw1L6HOF9J9eDHbXHnmMv8Q8=
 github.com/nuts-foundation/nuts-consent-store v0.0.0-20200114092308-3149bc4d9d8d h1:ZbRebPsW9VCcHmDqmRoVrhTUz6NDB0MPaSCZY5RfB30=
@@ -327,6 +331,8 @@ github.com/nuts-foundation/nuts-consent-store v0.0.0-20200127151538-f86b0e2b60e1
 github.com/nuts-foundation/nuts-consent-store v0.0.0-20200127151538-f86b0e2b60e1/go.mod h1:G/JookTUO3d7z/JI5T2d5uYkwFVv1QfYYFhtT6jo5Uk=
 github.com/nuts-foundation/nuts-consent-store v0.0.0-20200206083919-07f174baa8e2 h1:G5HNEt/5AaV/x3bUsBSJD6zOzOLs2lJEOUlgkzMGHlA=
 github.com/nuts-foundation/nuts-consent-store v0.0.0-20200206083919-07f174baa8e2/go.mod h1:bCTMClCXpKWoGtXjNl/HFOTV5zePPniMCjbr4rDKBQ4=
+github.com/nuts-foundation/nuts-consent-store v0.0.0-20200221113149-c393282605f5 h1:0Gre1QeyqmfSRZvBBzq1wiAdJ/PXa64A4vIRAA7pZm0=
+github.com/nuts-foundation/nuts-consent-store v0.0.0-20200221113149-c393282605f5/go.mod h1:vuq7dE6y587nC+lKXRoExt6hg4urCj+laCQ9njs/LPg=
 github.com/nuts-foundation/nuts-crypto v0.0.0-20191128090623-5ba9490632bb h1:YlV34Sfbw/FlFG/oymW7gj/HtFZbtwmfqZcc6PdBkjI=
 github.com/nuts-foundation/nuts-crypto v0.0.0-20191128090623-5ba9490632bb/go.mod h1:O+ACn2COL8q7rt9j0HT7TWf1eIRnqkKAJvHMifalsrE=
 github.com/nuts-foundation/nuts-crypto v0.0.0-20200108100158-4428c745d113 h1:jVYHWwCL5CvMD7AqjrBZpnEgZVS8DIeN7LhfyItyb64=
@@ -334,6 +340,8 @@ github.com/nuts-foundation/nuts-crypto v0.0.0-20200108100158-4428c745d113/go.mod
 github.com/nuts-foundation/nuts-crypto v0.0.0-20200122083151-b0465bb07bb5/go.mod h1:uIe/1AW3Zpm3xcxlK5+jLIbU2ksE6UM68mMb/IYahDo=
 github.com/nuts-foundation/nuts-crypto v0.0.0-20200127075335-afcefe897a71 h1:xa6aopX+cUjEjYwtlNJFmVYJZEZWfpDSIZC6ngYMOwQ=
 github.com/nuts-foundation/nuts-crypto v0.0.0-20200127075335-afcefe897a71/go.mod h1:uIe/1AW3Zpm3xcxlK5+jLIbU2ksE6UM68mMb/IYahDo=
+github.com/nuts-foundation/nuts-crypto v0.0.0-20200212103614-2acc644ddfed h1:xE3xIC7pNfbFo2hE2Ed/Y65XgGHYlmUKNZ1SYO/q2xg=
+github.com/nuts-foundation/nuts-crypto v0.0.0-20200212103614-2acc644ddfed/go.mod h1:txNGo50DqgKh6PLgBHaaen4BUyi/aEohxOWnOvLIndU=
 github.com/nuts-foundation/nuts-event-octopus v0.0.0-20191029153434-8e47d64e4f2b h1:NyxZreMSn+spCRsRu+v/2P3BuQv8xa51RDpODFVJDHk=
 github.com/nuts-foundation/nuts-event-octopus v0.0.0-20191029153434-8e47d64e4f2b/go.mod h1:DjmX+RVdGVYAtwIR9Z2cjKOzkvh0Dpy299GfPO5uimc=
 github.com/nuts-foundation/nuts-event-octopus v0.0.0-20200108100158-d97ffd8b5dc7 h1:otao7WvJcQDi0kCh+HCwrhdxO8YJdlbvV13ymZlA/5M=
@@ -344,6 +352,10 @@ github.com/nuts-foundation/nuts-event-octopus v0.0.0-20200128151335-f0023b5615f8
 github.com/nuts-foundation/nuts-event-octopus v0.0.0-20200128151335-f0023b5615f8/go.mod h1:c4L7yJTob5c/YtkUau/NQ9JQ64U0KbNsuRZIuhzxieA=
 github.com/nuts-foundation/nuts-event-octopus v0.0.0-20200206083853-1b0a343c1495 h1:EgLoNF5Es7DIpwxzd2NuADMP3m4iWn8sZ+gyrI5u34I=
 github.com/nuts-foundation/nuts-event-octopus v0.0.0-20200206083853-1b0a343c1495/go.mod h1:c4L7yJTob5c/YtkUau/NQ9JQ64U0KbNsuRZIuhzxieA=
+github.com/nuts-foundation/nuts-event-octopus v0.0.0-20200221072458-686600d788ca h1:g6uekrBCbXBB9DD0VZ8Q5559DIwWD8itQcjq4fQ/kgo=
+github.com/nuts-foundation/nuts-event-octopus v0.0.0-20200221072458-686600d788ca/go.mod h1:ULz4jGIapxnhlvwYs7/NIZyq+u9tR7wYLPWChYsFuL0=
+github.com/nuts-foundation/nuts-event-octopus v0.0.0-20200221101525-20c912b75512 h1:ARAjJd+RpQVI9AWjfzjBBNpSX8EzD3frrTAvep8oISg=
+github.com/nuts-foundation/nuts-event-octopus v0.0.0-20200221101525-20c912b75512/go.mod h1:HK/jKgRqvIwKz+zfrlAo5bJdzpZGCNYzVYD5UWARpbE=
 github.com/nuts-foundation/nuts-fhir-validation v0.0.0-20200106133706-43690c029d3d h1:FrwQAhp8XJn6ETlE1+ksnNGpRQKYZuvO6i2cKCBG+Vk=
 github.com/nuts-foundation/nuts-fhir-validation v0.0.0-20200106133706-43690c029d3d/go.mod h1:cKPyoodDvPAjDhW4Q/BtM2NWPgOoGFol1JzT6eWNXcQ=
 github.com/nuts-foundation/nuts-fhir-validation v0.0.0-20200108104034-2a3b8cc778c3 h1:CKe8U3xEGMkZLVXRACIR+Szd507HrOmxcYIcVGGs5Us=
@@ -363,6 +375,10 @@ github.com/nuts-foundation/nuts-go-core v0.0.0-20200128062821-3d36593be9c5 h1:yb
 github.com/nuts-foundation/nuts-go-core v0.0.0-20200128062821-3d36593be9c5/go.mod h1:xltL3S+vqhSMYkTRIWyaVgtDk7y8KIENZmTbVIPIMcw=
 github.com/nuts-foundation/nuts-go-core v0.0.0-20200130105519-4620adf455e9 h1:TN63qKwNTLVthdHy0z3FYAfwYoYfR1DEMhCFbjlEfU0=
 github.com/nuts-foundation/nuts-go-core v0.0.0-20200130105519-4620adf455e9/go.mod h1:xltL3S+vqhSMYkTRIWyaVgtDk7y8KIENZmTbVIPIMcw=
+github.com/nuts-foundation/nuts-go-core v0.0.0-20200220093939-3a4292f30472 h1:VxcYvZY14fYJOPEJ3YorptibMU9NLw9UNQfBxEYEJaw=
+github.com/nuts-foundation/nuts-go-core v0.0.0-20200220093939-3a4292f30472/go.mod h1:xltL3S+vqhSMYkTRIWyaVgtDk7y8KIENZmTbVIPIMcw=
+github.com/nuts-foundation/nuts-go-core v0.0.0-20200221103113-05e1c6b6c5fc h1:3ze3s0e0ZC38Q+TUVZ0BAV8m4wz+AN06HW3WKIYa+Ig=
+github.com/nuts-foundation/nuts-go-core v0.0.0-20200221103113-05e1c6b6c5fc/go.mod h1:xltL3S+vqhSMYkTRIWyaVgtDk7y8KIENZmTbVIPIMcw=
 github.com/nuts-foundation/nuts-registry v0.0.0-20191209153959-67dd0910b057 h1:kn5VkvVJWdf0suyC2AO6QlGEK+0V62Vv6B54mINecmo=
 github.com/nuts-foundation/nuts-registry v0.0.0-20191209153959-67dd0910b057/go.mod h1:zj8lpRLEYlJkC7fo+c8NO7pjkSXR3DvvpyyJ2YSiBKU=
 github.com/nuts-foundation/nuts-registry v0.0.0-20200108100157-f61ac82980f3 h1:voUFUGUDXBEYX8wJKzHRAYcOH/rc5VIaRPWwg3wmP90=
@@ -372,6 +388,8 @@ github.com/nuts-foundation/nuts-registry v0.0.0-20200127075454-daac48a7b1e0 h1:R
 github.com/nuts-foundation/nuts-registry v0.0.0-20200127075454-daac48a7b1e0/go.mod h1:CbF87EcYRywizqTybDTzYwCi3uRbP3jYaFJBxMJpRaU=
 github.com/nuts-foundation/nuts-registry v0.0.0-20200211142433-9d1d2985be8e h1:G5MR+N/fMMQrcwbITkmqhhkJLM/1HAyned2Tp/Ik8zU=
 github.com/nuts-foundation/nuts-registry v0.0.0-20200211142433-9d1d2985be8e/go.mod h1:CbF87EcYRywizqTybDTzYwCi3uRbP3jYaFJBxMJpRaU=
+github.com/nuts-foundation/nuts-registry v0.0.0-20200221092912-d62eff310549 h1:l31t2Ozo299vtonZ35yxqsqtGqUFwGXyXCGUy+hDaqw=
+github.com/nuts-foundation/nuts-registry v0.0.0-20200221092912-d62eff310549/go.mod h1:s07mLtaw5dE5UWTPFOPgZGeOHa82lZ7Gdt+ltmF1fmw=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
Fixes #11 

- Add support for it in all engines and update go.mod here:
  - consent store: https://github.com/nuts-foundation/nuts-consent-store/pull/37
  - event octopus: https://github.com/nuts-foundation/nuts-event-octopus/pull/13
  - event logic: https://github.com/nuts-foundation/nuts-consent-logic/pull/28
  - registry: https://github.com/nuts-foundation/nuts-registry/pull/38
  - auth: https://github.com/nuts-foundation/nuts-auth/pull/36